### PR TITLE
Fix/json remove control chars

### DIFF
--- a/javascript/engine-js/src/view/TokenViewData.ts
+++ b/javascript/engine-js/src/view/TokenViewData.ts
@@ -59,7 +59,7 @@ export class TokenViewData {
 
 		const walletAdapter = await this.tokenScript.getEngine().getWalletAdapter();
 
-		const currentTokenInstance = JSON.parse(`${JSON.stringify(tokenData).replace("^\\'", "\\'").replace(/[\u0000-\u001F]/g, "")}`);
+		const currentTokenInstance = JSON.parse(`${JSON.stringify(tokenData).replace("^\\'", "\\'")}`);
 
 		return `
 


### PR DESCRIPTION
Hi guys, as we talked about in discord. I testing around 15 NFT collections via the TS Viewer, where the engine failed in some of the tests carried out to parse the collections data, warning there were control Unicode Characters in the formatting. 

Please see this PR to help us resolve this. 