### PR TITLE
Fix: Sizing update applied to ensure NFT images fit within different aspect ratio iframe dimensions.

### DIFF
--- a/javascript/tokenscript-viewer/src/components/viewers/opensea/opensea-viewer.css
+++ b/javascript/tokenscript-viewer/src/components/viewers/opensea/opensea-viewer.css
@@ -30,9 +30,10 @@ body {
 .opensea-img-container {
 	display: flex;
 	flex-grow: 1;
-	background-size: cover;
 	background-repeat: no-repeat;
-	background-position: top;
+	background-size: contain;
+	background-color: white;
+	background-position: center;
 }
 
 .info-button, .close-button {


### PR DESCRIPTION
Sizing update applied to ensure NFT images fit within different aspect ratio iframe dimensions.

- Updates to `.opensea-img-container` class 
- Tested updates at different aspect ratio's

Screen shots to demonstrate changes applied (H > W & W > H):

<img width="504" alt="Screenshot 2024-03-07 at 10 57 11 am" src="https://github.com/SmartTokenLabs/tokenscript-engine/assets/6808817/b5cc9783-320f-431a-a0d6-651bcdaff461">

<img width="891" alt="Screenshot 2024-03-07 at 10 57 01 am" src="https://github.com/SmartTokenLabs/tokenscript-engine/assets/6808817/7089f453-324a-45c9-8a59-d35313f924d1">
