### PR TITLE
Update app.tsx generalise viewer type naming convention

### DIFF
--- a/javascript/tokenscript-viewer/src/components/app/app.tsx
+++ b/javascript/tokenscript-viewer/src/components/app/app.tsx
@@ -32,8 +32,6 @@ const initViewerType = (params: URLSearchParams): ViewerTypes => {
 
 	let viewerType;
 
-	if (viewerType === 'marketplace') viewerType = 'opensea';
-
 	switch (params.get("viewType")){
 		case "integration":
 			viewerType = "integration";
@@ -45,6 +43,7 @@ const initViewerType = (params: URLSearchParams): ViewerTypes => {
 			viewerType = "joyid-token";
 			break;
 		case "opensea":
+		case 'marketplace':
 			viewerType = "opensea";
 			break;
 		case "sts-token":


### PR DESCRIPTION
This task is to allow for future collections that use animation url to implement 'marketplace' instead of 'opensea' as the viewer type, to make this solution naming convention more generic. This to save confusion with other market places we work with that this link will be navigating users to opensea which it doesn't.

@micwallace please let me know your thoughts on the naming convention applied. Where this could be made more detailed, e.g. 'marketplace-readonly' or just 'readonly' 

