### PR TITLE
feat: 🎸 share to telegram

### DIFF
--- a/javascript/tokenscript-viewer/src/components/viewers/new/new-viewer.tsx
+++ b/javascript/tokenscript-viewer/src/components/viewers/new/new-viewer.tsx
@@ -7,6 +7,7 @@ import {WalletConnection, Web3WalletProvider} from "../../wallet/Web3WalletProvi
 import {DiscoveryAdapter} from "../../../integration/discoveryAdapter";
 import {CHAIN_MAP} from "../../../integration/constants";
 import {connectEmulatorSocket} from "../util/connectEmulatorSocket";
+import { decodeSafeBase64QueryString } from '../util/tgUrl';
 
 type LoadedTokenScript = (TokenScriptsMeta & {tokenScript?: TokenScript});
 
@@ -60,6 +61,18 @@ export class NewViewer {
 		this.init();
 		this.processUrlLoad();
 	}
+
+
+	componentDidLoad() {
+		// if it's coming from Telegram, then we redirect to the url with query params
+		const urlParams = new URLSearchParams(window.location.search);
+		const startParam = urlParams.get('tgWebAppStartParam');
+		if (startParam) {
+			const query = decodeSafeBase64QueryString(startParam);
+			window.location.href = `${window.location.origin}${window.location.pathname}?${query}`;
+		}
+  }
+
 
 	private async processUrlLoad(){
 

--- a/javascript/tokenscript-viewer/src/components/viewers/new/viewer-popover/viewer-popover.tsx
+++ b/javascript/tokenscript-viewer/src/components/viewers/new/viewer-popover/viewer-popover.tsx
@@ -6,6 +6,7 @@ import {handleTransactionError, showTransactionNotification} from "../../util/sh
 import {ShowToastEventArgs} from "../../../app/app";
 import {TokenGridContext} from "../../util/getTokensFlat";
 import {ScriptSourceType} from "../../../../../../engine-js/src/Engine";
+import { getTgUrl } from '../../util/tgUrl';
 
 @Component({
 	tag: 'viewer-popover',
@@ -23,6 +24,9 @@ export class ViewerPopover {
 
 	@State()
 	onboardingCards?: Card[];
+
+	@State()
+	showTgButton: boolean = false;
 
 	@Event({
 		eventName: 'showToast',
@@ -48,6 +52,20 @@ export class ViewerPopover {
 	@State()
 	private overflowCardButtons: JSX.Element[];
 	private overflowDialog: HTMLActionOverflowModalElement;
+
+	componentWillLoad() {
+		const storedSetting = localStorage.getItem('showTgButton');
+		this.showTgButton = storedSetting === 'true';
+
+		const urlParams = new URLSearchParams(window.location.search);
+		const enableTg = urlParams.get('showTgButton');
+
+		if (enableTg === 'true') {
+			this.showTgButton = true;
+			localStorage.setItem('showTgButton', 'true');
+		}
+	}
+
 
 	@Method()
 	async open(tokenScript: TokenScript){
@@ -176,6 +194,17 @@ export class ViewerPopover {
 						<h3>{this.tokenScript.getLabel(2) ?? this.tokenScript.getName()}</h3>
 					</div>
 					<div class="view-toolbar-buttons">
+						{this.showTgButton && <div>
+							<a
+								href={getTgUrl()}
+								target='_blank'
+								class="btn"
+								style={{marginRight: "5px", minWidth: "35px", fontSize: "16px"}}
+								title="Share on Telegram"
+							>
+								<img src='https://telegram.org/img/apple-touch-icon.png' style={{width: '100%', height: '100%'}}/>
+							</a>
+						</div>}
 						<security-status tokenScript={this.tokenScript}/>
 						<div>
 							<button class="btn" style={{marginRight: "5px", minWidth: "35px", fontSize: "16px"}}
@@ -224,3 +253,4 @@ export class ViewerPopover {
 		)
 	}
 }
+

--- a/javascript/tokenscript-viewer/src/components/viewers/util/tgUrl.ts
+++ b/javascript/tokenscript-viewer/src/components/viewers/util/tgUrl.ts
@@ -1,0 +1,34 @@
+const TG_URL = 'https://t.me/SmartLayerBot/SmartTokenViewer/';
+
+export function getTgUrl() {
+	const query = window.location.href.split('?')[1]
+	if (query) {
+		const decodedQueryString = decodeURIComponent(query);
+		const base64Encoded = btoa(decodedQueryString)
+			.replace(/\+/g, '-')
+			.replace(/\//g, '_')
+			.replace(/=+$/, '');;
+		return `${TG_URL}?startapp=${base64Encoded}`;
+	} else {
+		return TG_URL
+	}
+}
+
+
+export function decodeSafeBase64QueryString(encodedString: string) {
+  try {
+    let base64 = encodedString.replace(/-/g, '+').replace(/_/g, '/');
+
+    while (base64.length % 4) {
+      base64 += '=';
+    }
+
+    const decodedQuery = atob(base64);
+
+    return decodedQuery;
+  } catch (error) {
+    console.error('Error decoding Base64 string:', error);
+    return null;
+  }
+}
+


### PR DESCRIPTION
here are the features in this PR:
- add a button to share to Telegram(it will open a telegram mini app and open TokenScript Viewer there)
- the button will be under feature toggle, `?showTgButton=true` to toggle it on
- it will encode the queries for example `chain` and `contract`, and encode it then pass it to telegram
- when Telegram open TokenScript Viewer, it will add `tgWebAppStartParam` in the url, if we find it, then redirect to the token url directly