### PR TITLE
chore: 🎸 lock pkijs version to 3.1.0 which we have created patch for

### DIFF
--- a/javascript/engine-js/package-lock.json
+++ b/javascript/engine-js/package-lock.json
@@ -19,6 +19,7 @@
         "ipfs-only-hash": "^4.0.0",
         "jsdom": "^22.1.0",
         "lodash": "^4.17.21",
+        "pkijs": "3.1.0",
         "webcrypto-liner": "^1.4.3"
       },
       "devDependencies": {

--- a/javascript/engine-js/package.json
+++ b/javascript/engine-js/package.json
@@ -39,15 +39,14 @@
     "ipfs-only-hash": "^4.0.0",
     "jsdom": "^22.1.0",
     "lodash": "^4.17.21",
+    "pkijs": "3.1.0",
     "webcrypto-liner": "^1.4.3"
   },
   "overrides": {
     "xml-core": {
       "@xmldom/xmldom": "^0.9.0-beta.6"
     },
-    "xmldsigjs": {
-      "pkijs": "3.0.11"
-    },
+    "pkijs": "3.1.0",
     "elliptic": "^6.5.4"
   }
 }


### PR DESCRIPTION
Try to lock the pkijs version to 3.1.0, based on which we created patch