### PR TITLE
feat: 🎸 change the name of xnft inside opensea viewer to tapp.

### DIFF
--- a/javascript/tokenscript-viewer/src/components/viewers/opensea/opensea-viewer.css
+++ b/javascript/tokenscript-viewer/src/components/viewers/opensea/opensea-viewer.css
@@ -27,7 +27,7 @@ body {
 
 .opensea-header span {
 	font-size: 12px;
-	padding-left: 10px;
+	padding-left: 16px;
 	font-weight: bold;
 }
 

--- a/javascript/tokenscript-viewer/src/components/viewers/opensea/opensea-viewer.tsx
+++ b/javascript/tokenscript-viewer/src/components/viewers/opensea/opensea-viewer.tsx
@@ -179,7 +179,7 @@ export class OpenseaViewer {
 				</div>
 				<div class="opensea-header">
 					<a href="https://www.smartlayer.network/" target="_blank">
-						<span>XNFT by</span>
+						<span>tapp by</span>
 						<img class="header-icon" alt="SmartLayer Network" src="assets/icon/smart-layer-icon.png"/>
 					</a>
 				</div>


### PR DESCRIPTION
- Updated the naming of XNFT to tapp inside the Opensea viewer.
- Added slight extra left padding to text to improve the UI on marketplaces with strong NFT container rounded edges
- Tested locally to ensure changes are applied / nothing has regressed from update

@micwallace could you help review this update and deploy this change. Thanks.